### PR TITLE
fix: remove constructor in interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { Application, Context, PlainObject } from 'egg';
+import { Application, PlainObject } from 'egg';
 
 interface RenderOptions extends PlainObject {
   name?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,7 +28,6 @@ interface ViewBase {
 }
 
 interface ViewManager extends Map<string, any> {
-  constructor(app: Application);
   use(name: string, viewEngine: ViewBase): void;
   resolve(name: string): Promise<string>;
 }
@@ -36,7 +35,6 @@ interface ViewManager extends Map<string, any> {
 interface ContextView extends ViewBase {
   app: Application;
   viewManager: ViewManager;
-  constructor(ctx: Context);
 }
 
 declare module 'egg' {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

此前提交的声明中，本来 ContextView 这几个是用的 class ，后来改成 interface 的时候忘记删掉 constructor 了，这个对使用无影响，只是从语法层面来说不合理，所以还是改一下 。